### PR TITLE
chore: add a simple CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,9 @@ jobs:
             --message-format=json \
             | cargo-action-fmt
         env:
-          RUSTDOCFLAGS: "--cfg docsrs -D warnings"
+          # Explicitly enable the cortex-m config so that cortex-m-only code
+          # gets documented.
+          RUSTDOCFLAGS: "--cfg docsrs --cfg cortex_m -D warnings"
 
   # "Good to merge" job that depends on all required checks.
   #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,79 @@
+on:
+    pull_request:
+    workflow_dispatch:
+    push:
+      branches: ["main"]
+
+name: CI
+
+jobs:
+  clippy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            override: true
+      - uses: olix0r/cargo-action-fmt/setup@v2
+      - uses: actions/checkout@v2
+      - name: cargo clippy
+        run: cargo clippy -q --message-format=json | cargo-action-fmt
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: stable
+            override: true
+      - name: cargo test
+        run: cargo test --all
+
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+          components: rustfmt
+      - name: cargo fmt
+        run: cargo fmt --all -- --check
+
+  rustdoc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+      - uses: olix0r/cargo-action-fmt/setup@v2
+      - uses: actions/checkout@v2
+      - name: cargo doc
+        run: cargo doc --all -q --message-format=json | cargo-action-fmt
+        env:
+          RUSTDOCFLAGS: "--cfg docsrs -D warnings"
+
+  # "Good to merge" job that depends on all required checks.
+  #
+  # This is so that we can just make GitHub require this to merge, and the list
+  # of required checks can be declared here, rather than in the UI.
+  all-systems-go:
+    name: "all systems go!"
+    runs-on: ubuntu-latest
+    needs:
+      - rustfmt
+      - rustdoc
+      - clippy
+      - test
+    steps:
+      - run: exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,13 @@ jobs:
       - uses: olix0r/cargo-action-fmt/setup@v2
       - uses: actions/checkout@v2
       - name: cargo doc
-        run: cargo doc --all -q --message-format=json | cargo-action-fmt
+        run: |
+          cargo doc \
+            --all \
+            --all-features \
+            --quiet \
+            --message-format=json \
+            | cargo-action-fmt
         env:
           RUSTDOCFLAGS: "--cfg docsrs -D warnings"
 

--- a/source/scoped-mutex-traits/Cargo.toml
+++ b/source/scoped-mutex-traits/Cargo.toml
@@ -14,7 +14,9 @@ categories = [
 ]
 documentation = "https://docs.rs/mutex-traits/"
 
+[features]
+std = []
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
-

--- a/source/scoped-mutex/src/lib.rs
+++ b/source/scoped-mutex/src/lib.rs
@@ -4,8 +4,8 @@
 
 pub mod raw_impls;
 
-pub use mutex_traits::{ConstInit, ScopedRawMutex};
 use core::cell::UnsafeCell;
+pub use mutex_traits::{ConstInit, ScopedRawMutex};
 
 /// Blocking mutex (not async)
 ///

--- a/source/scoped-mutex/src/raw_impls.rs
+++ b/source/scoped-mutex/src/raw_impls.rs
@@ -171,7 +171,7 @@ pub mod single_core_thread_mode {
     unsafe impl ScopedRawMutex for ThreadModeRawMutex {
         #[inline]
         #[must_use]
-        fn try_lock<R>(&self, f: impl FnOnce() -> R) -> Option<R> {
+        fn try_with_lock<R>(&self, f: impl FnOnce() -> R) -> Option<R> {
             if !in_thread_mode() {
                 return None;
             }
@@ -185,7 +185,7 @@ pub mod single_core_thread_mode {
         }
 
         #[inline]
-        fn lock<R>(&self, f: impl FnOnce() -> R) -> R {
+        fn with_lock<R>(&self, f: impl FnOnce() -> R) -> R {
             // In a thread-mode only mutex, it is not possible for another holder
             // of this mutex to release, which means we have certainly
             // reached deadlock if the lock was already locked.
@@ -213,7 +213,7 @@ pub mod single_core_thread_mode {
         }
     }
 
-    pub fn in_thread_mode() -> bool {
+    fn in_thread_mode() -> bool {
         // ICSR.VECTACTIVE == 0
         return unsafe { (0xE000ED04 as *const u32).read_volatile() } & 0x1FF == 0;
     }

--- a/source/scoped-mutex/src/raw_impls.rs
+++ b/source/scoped-mutex/src/raw_impls.rs
@@ -218,4 +218,3 @@ pub mod single_core_thread_mode {
         return unsafe { (0xE000ED04 as *const u32).read_volatile() } & 0x1FF == 0;
     }
 }
-


### PR DESCRIPTION
This branch adds a quick and dirty GitHub Actions CI config. 

We may want to think about stuff like trying to build for different platforms (e.g. cortex-m), MSRV checking, etc, but we can do that later --- right now, I just wanted to get something basic working, because that seemed better than nothing.