### PR TITLE
mutex: Add (optional) `fmt::{Debug, Display}` impls

### DIFF
--- a/source/scoped-mutex/Cargo.toml
+++ b/source/scoped-mutex/Cargo.toml
@@ -38,4 +38,8 @@ default = [
 impl-critical-section = ["dep:critical-section"]
 impl-unsafe-cortex-m-single-core = []
 impl-lock_api-0_4 = ["dep:lock_api-0_4"]
+# Enables `fmt::Debug` and `fmt::Display` implementations.
+#
+# These can be disabled when minimizing binary size is important.
+fmt = []
 std = []

--- a/source/scoped-mutex/src/raw_impls.rs
+++ b/source/scoped-mutex/src/raw_impls.rs
@@ -24,6 +24,7 @@ pub mod cs {
     /// # Safety
     ///
     /// This mutex is safe to share between different executors and interrupts.
+    #[cfg_attr(feature = "fmt", derive(Debug))]
     pub struct CriticalSectionRawMutex {
         taken: AtomicBool,
     }
@@ -84,6 +85,7 @@ pub mod local {
     ///
     /// This acts similar to a RefCell, with scoped access patterns, though
     /// without being able to borrow the data twice.
+    #[cfg_attr(feature = "fmt", derive(Debug))]
     pub struct LocalRawMutex {
         taken: AtomicBool,
         /// Prevent this from being sync or send
@@ -150,6 +152,7 @@ pub mod single_core_thread_mode {
     /// **This Mutex is only safe on single-core systems.**
     ///
     /// On multi-core systems, a `ThreadModeRawMutex` **is not sufficient** to ensure exclusive access.
+    #[cfg_attr(feature = "fmt", derive(Debug))]
     pub struct ThreadModeRawMutex {
         taken: AtomicBool,
     }
@@ -231,6 +234,7 @@ pub mod lock_api_0_4 {
 
     /// [`lock_api`](https://crates.io/crates/lock_api) v0.4 [`RawMutex`]
     /// implementation.
+    #[cfg_attr(feature = "fmt", derive(Debug))]
     pub struct LockApiRawMutex<T>(T);
 
     impl<T: lock_api::RawMutex> ConstInit for LockApiRawMutex<T> {


### PR DESCRIPTION
Depends on #3

I made these optional so that embedded projects that care about optimizing for binary size can leave them disabled. They're opt-in, rather than on by default, because I figured it would be easy for libraries to just enable them by accident if they were default-on.

We may, also, want to consider adding a similar feature for `defmt` support, but I'd prefer to do that separately.