### PR TITLE
mutex: use the proper `default-features`

### DIFF
--- a/source/mutex/Cargo.toml
+++ b/source/mutex/Cargo.toml
@@ -28,7 +28,7 @@ optional = true
 [dependencies.lock_api-0_4]
 package = "lock_api"
 version = "0.4"
-default_features = false
+default-features = false
 optional = true
 
 [features]


### PR DESCRIPTION
Cargo now warns about the use of `default_features` rather than `default-features`, as it is deprecated and will be removed in Rust
2024. See: https://github.com/tosc-rs/scoped-mutex/actions/runs/10332778501/job/28604380142