### PR TITLE
Add docs to help choosing a lock impl

### DIFF
--- a/source/mutex/Cargo.toml
+++ b/source/mutex/Cargo.toml
@@ -15,7 +15,7 @@ repository.workspace = true
 
 [package.metadata.docs.rs]
 all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+rustdoc-args = ["--cfg", "docsrs", "--cfg", "cortex_m"]
 
 [dependencies.mutex-traits]
 version = "1.0.0"


### PR DESCRIPTION
Also enables features for docsrs so all impls are shown.

Also removes some incorrect docs (`local` DOES impl `Send`, but does NOT impl `Sync`).

Closes #16

CC @Vollbrecht