### PR TITLE
Implement `RwaMutex` for `LocalRawMutex` and `ThreadModeRawMutex`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "7059fff8937831a9ae6f0fe4d658ffabf58f2ca96aa9dec1c889f936f705f216"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",

--- a/source/mutex-traits/Cargo.toml
+++ b/source/mutex-traits/Cargo.toml
@@ -15,8 +15,16 @@ categories = [
 documentation = "https://docs.rs/mutex-traits/"
 
 [features]
+default = ["compatible-with-lock_api-0_4"]
 std = []
+compatible-with-lock_api-0_4 = ["dep:lock_api-0_4"]
 
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
+
+[dependencies.lock_api-0_4]
+package = "lock_api"
+version = "0.4"
+default-features = false
+optional = true

--- a/source/mutex-traits/src/impl_for_lock_api.rs
+++ b/source/mutex-traits/src/impl_for_lock_api.rs
@@ -1,0 +1,34 @@
+use crate::{ConstInit, RawMutex};
+use lock_api_0_4 as lock_api;
+
+impl<R: lock_api::RawMutex> ConstInit for R {
+    const INIT: Self = R::INIT;
+}
+
+unsafe impl<R: lock_api::RawMutex> RawMutex for R {
+    type GuardMarker = R::GuardMarker;
+
+    #[inline]
+    #[track_caller]
+    fn try_lock(&self) -> bool {
+        lock_api::RawMutex::try_lock(self)
+    }
+
+    #[inline]
+    #[track_caller]
+    fn lock(&self) {
+        lock_api::RawMutex::lock(self)
+    }
+
+    #[inline]
+    #[track_caller]
+    unsafe fn unlock(&self) {
+        lock_api::RawMutex::unlock(self)
+    }
+
+    #[inline]
+    #[track_caller]
+    fn is_locked(&self) -> bool {
+        lock_api::RawMutex::is_locked(self)
+    }
+}

--- a/source/mutex-traits/src/lib.rs
+++ b/source/mutex-traits/src/lib.rs
@@ -3,6 +3,9 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
 
+#[cfg(feature = "compatible-with-lock_api-0_4")]
+mod impl_for_lock_api;
+
 /// Const Init Trait
 ///
 /// This trait is intended for use when implementers of [`ScopedRawMutex`] that can
@@ -82,7 +85,7 @@ pub unsafe trait ScopedRawMutex {
 /// Some mutex implementations may not be able to implement the full `RawMutex`
 /// trait, and may only be able to implement the closure-based
 /// [`ScopedRawMutex`] subset. For example, implementations for the
-/// [`critical-section`] crate (in [`mutex::raw_impls::cs`][cs]) can only
+/// `critical-section` crate (in [`mutex::raw_impls::cs`][cs]) can only
 /// implement the `ScopedRawMutex` trait. However, in general, **mutex
 /// implementations that *can* implement the more general `RawMutex` trait
 /// should prefer to do so**, as they will be able to be used in code that

--- a/source/mutex/Cargo.toml
+++ b/source/mutex/Cargo.toml
@@ -31,6 +31,9 @@ version = "0.4"
 default-features = false
 optional = true
 
+[dev-dependencies]
+parking_lot = "0.12"
+
 [features]
 default = [
     "impl-critical-section",
@@ -38,6 +41,7 @@ default = [
 impl-critical-section = ["dep:critical-section"]
 impl-unsafe-cortex-m-single-core = []
 impl-lock_api-0_4 = ["dep:lock_api-0_4"]
+compatible-with-lock_api-0_4 = ["mutex-traits/compatible-with-lock_api-0_4"]
 # Enables `fmt::Debug` and `fmt::Display` implementations.
 #
 # These can be disabled when minimizing binary size is important.

--- a/source/mutex/src/lib.rs
+++ b/source/mutex/src/lib.rs
@@ -456,4 +456,24 @@ mod test {
         .unwrap();
         assert_eq!(Some(1), res);
     }
+
+    #[cfg(feature = "compatible-with-lock_api-0_4")]
+    #[test]
+    fn lock_api_compatibility() {
+        let mutex = BlockingMutex::<parking_lot::RawMutex, u32>::new(0);
+        let mut guard = mutex.lock();
+        assert_eq!(*guard, 0);
+        *guard = 1;
+        drop(guard);
+
+        let mut guard = mutex.lock();
+        assert_eq!(*guard, 1);
+        *guard = 2;
+        drop(guard);
+
+        mutex.with_lock(|data| {
+            assert_eq!(*data, 2);
+            *data = 3;
+        });
+    }
 }


### PR DESCRIPTION
Given that `LocalRawMutex` and `ThreadModeRawMutex` are simple modules, I implement `RwaMutex` for them to make them more useful.